### PR TITLE
Create user with a group number and create a log directory

### DIFF
--- a/3.3.6/Dockerfile
+++ b/3.3.6/Dockerfile
@@ -10,6 +10,7 @@ ENV ZOO_USER=zookeeper \
     ZOO_CONF_DIR=/conf \
     ZOO_DATA_DIR=/data \
     ZOO_DATA_LOG_DIR=/datalog \
+    ZOO_LOG_DIR=/logs \
     ZOO_PORT=2181 \
     ZOO_TICK_TIME=2000 \
     ZOO_INIT_LIMIT=5 \
@@ -18,9 +19,9 @@ ENV ZOO_USER=zookeeper \
 
 # Add a user and make dirs
 RUN set -ex; \
-    adduser -D "$ZOO_USER"; \
-    mkdir -p "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR"; \
-    chown "$ZOO_USER:$ZOO_USER" "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR"
+    adduser -D -u 9001"$ZOO_USER"; \
+    mkdir -p "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR" "$ZOO_LOG_DIR"; \
+    chown "$ZOO_USER:$ZOO_USER" "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR" "$ZOO_LOG_DIR"
 
 ARG GPG_KEY=D0BC8D8A4E90A40AFDFC43B3E22A746A68E327C1
 ARG DISTRO_NAME=zookeeper-3.3.6

--- a/3.3.6/docker-entrypoint.sh
+++ b/3.3.6/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 # Allow the container to be started with `--user`
 if [ "$1" = 'zkServer.sh' -a "$(id -u)" = '0' ]; then
-    chown -R "$ZOO_USER" "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR"
+    chown -R "$ZOO_USER" "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR"
     exec su-exec "$ZOO_USER" "$0" "$@"
 fi
 

--- a/3.4.10/Dockerfile
+++ b/3.4.10/Dockerfile
@@ -10,6 +10,7 @@ ENV ZOO_USER=zookeeper \
     ZOO_CONF_DIR=/conf \
     ZOO_DATA_DIR=/data \
     ZOO_DATA_LOG_DIR=/datalog \
+    ZOO_LOG_DIR=/logs \
     ZOO_PORT=2181 \
     ZOO_TICK_TIME=2000 \
     ZOO_INIT_LIMIT=5 \
@@ -18,9 +19,9 @@ ENV ZOO_USER=zookeeper \
 
 # Add a user and make dirs
 RUN set -ex; \
-    adduser -D "$ZOO_USER"; \
-    mkdir -p "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR"; \
-    chown "$ZOO_USER:$ZOO_USER" "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR"
+    adduser -D -u 9001 "$ZOO_USER"; \
+    mkdir -p "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR" "$ZOO_LOG_DIR"; \
+    chown "$ZOO_USER:$ZOO_USER" "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR" "$ZOO_LOG_DIR"
 
 ARG GPG_KEY=C823E3E5B12AF29C67F81976F5CECB3CB5E9BD2D
 ARG DISTRO_NAME=zookeeper-3.4.10

--- a/3.4.10/docker-entrypoint.sh
+++ b/3.4.10/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 # Allow the container to be started with `--user`
 if [ "$1" = 'zkServer.sh' -a "$(id -u)" = '0' ]; then
-    chown -R "$ZOO_USER" "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR"
+    chown -R "$ZOO_USER" "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR"  "$ZOO_LOG_DIR"
     exec su-exec "$ZOO_USER" "$0" "$@"
 fi
 

--- a/3.5.3-beta/Dockerfile
+++ b/3.5.3-beta/Dockerfile
@@ -9,6 +9,7 @@ ENV ZOO_USER=zookeeper \
     ZOO_CONF_DIR=/conf \
     ZOO_DATA_DIR=/data \
     ZOO_DATA_LOG_DIR=/datalog \
+    ZOO_LOG_DIR=/logs \
     ZOO_PORT=2181 \
     ZOO_TICK_TIME=2000 \
     ZOO_INIT_LIMIT=5 \
@@ -18,9 +19,9 @@ ENV ZOO_USER=zookeeper \
 
 # Add a user and make dirs
 RUN set -ex; \
-    adduser -D "$ZOO_USER"; \
-    mkdir -p "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR"; \
-    chown "$ZOO_USER:$ZOO_USER" "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR"
+    adduser -D -u 9001 "$ZOO_USER"; \
+    mkdir -p "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR" "$ZOO_LOG_DIR"; \
+    chown "$ZOO_USER:$ZOO_USER" "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR" "$ZOO_LOG_DIR"
 
 ARG GPG_KEY=C61B346552DC5E0CB53AA84F59147497767E7473
 ARG DISTRO_NAME=zookeeper-3.5.3-beta
@@ -46,7 +47,7 @@ RUN set -ex; \
     chown -R "$ZOO_USER:$ZOO_USER" "/$DISTRO_NAME"
 
 WORKDIR $DISTRO_NAME
-VOLUME ["$ZOO_DATA_DIR", "$ZOO_DATA_LOG_DIR"]
+VOLUME ["$ZOO_DATA_DIR", "$ZOO_DATA_LOG_DIR", "$ZOO_LOG_DIR"]
 
 EXPOSE $ZOO_PORT 2888 3888
 

--- a/3.5.3-beta/docker-entrypoint.sh
+++ b/3.5.3-beta/docker-entrypoint.sh
@@ -23,7 +23,7 @@ if [ ! -f "$ZOO_CONF_DIR/zoo.cfg" ]; then
     echo "standaloneEnabled=$ZOO_STANDALONE_ENABLED" >> "$CONFIG"
 
     if [ -z $ZOO_SERVERS ]; then
-      echo "ZOO_SERVERS=\"server.1=localhost:2888:3888;$ZOO_PORT\""
+      echo "server.1=localhost:2888:3888;$ZOO_PORT"
     else
       for server in $ZOO_SERVERS; do
           echo "$server" >> "$CONFIG"

--- a/3.5.3-beta/docker-entrypoint.sh
+++ b/3.5.3-beta/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 # Allow the container to be started with `--user`
 if [ "$1" = 'zkServer.sh' -a "$(id -u)" = '0' ]; then
-    chown -R "$ZOO_USER" "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR"
+    chown -R "$ZOO_USER" "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR"
     exec su-exec "$ZOO_USER" "$0" "$@"
 fi
 
@@ -23,12 +23,12 @@ if [ ! -f "$ZOO_CONF_DIR/zoo.cfg" ]; then
     echo "standaloneEnabled=$ZOO_STANDALONE_ENABLED" >> "$CONFIG"
 
     if [ -z $ZOO_SERVERS ]; then
-      ZOO_SERVERS="server.1=localhost:2888:3888;$ZOO_PORT"
+      echo "ZOO_SERVERS=\"server.1=localhost:2888:3888;$ZOO_PORT\""
+    else
+      for server in $ZOO_SERVERS; do
+          echo "$server" >> "$CONFIG"
+      done
     fi
-
-    for server in $ZOO_SERVERS; do
-        echo "$server" >> "$CONFIG"
-    done
 fi
 
 # Write myid only if it doesn't exist


### PR DESCRIPTION
Creating a user with a group number shouldn't be necessary, but it's a limitation within docker if you'd like to ever run a processes as a non-root user and ever mount a directory to the container that has the right privelages. Adding the number won't affect any current users of the app, but will give more flexibility to those who wish to also create a user with an ID of `9001` and use it to map a log directory or other directory for the host OS to view.

By default, logging is not turned on, but one could turn it on by adding `ROLLINGFILE` to the `ZOO_LOG4J_PROP` container variable.