### PR TITLE
Add "$ZOO_CONF_DIR" to chown list in start script

### DIFF
--- a/3.4.13/docker-entrypoint.sh
+++ b/3.4.13/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 # Allow the container to be started with `--user`
 if [[ "$1" = 'zkServer.sh' && "$(id -u)" = '0' ]]; then
-    chown -R "$ZOO_USER" "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR"
+    chown -R "$ZOO_USER" "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR" "$ZOO_CONF_DIR"
     exec su-exec "$ZOO_USER" "$0" "$@"
 fi
 

--- a/3.5.4-beta/docker-entrypoint.sh
+++ b/3.5.4-beta/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 # Allow the container to be started with `--user`
 if [[ "$1" = 'zkServer.sh' && "$(id -u)" = '0' ]]; then
-    chown -R "$ZOO_USER" "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR"
+    chown -R "$ZOO_USER" "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR" "$ZOO_CONF_DIR"
     exec su-exec "$ZOO_USER" "$0" "$@"
 fi
 


### PR DESCRIPTION
when i set ZOO_USER,  i can not `echo` to ZOO_CONF_DIR
```
docker run  \
    --rm \
    --name zk1 \
    -p 2181:2181 \
    -p 2888:2888 \
    -p 3888:3888 \
    -e ZOO_USER=`whoami` \
    -e ZOO_MY_ID=1 \
    -e ZOO_SERVERS="server.1=0.0.0.0:2888:3888 server.2=node2:2888:3889 server.3=node3:2888:3888" \
    -v "/some:/data" \
    -v "/some:/datalog" \
    -v "/some:/logs" \
    -v "/etc/passwd:/etc/passwd:ro" \
    zookeeper:3.4
```
got this
```
/docker-entrypoint.sh: line 15: /conf/zoo.cfg: Permission denied
```