### PR TITLE
Readme : expose ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ services:
         hostname: zoo1
         ports:
             - 2181:2181
+	    - 2888:2888
+	    - 3888:3888
         environment:
             ZOO_MY_ID: 1
-            ZOO_SERVERS: server.1=0.0.0.0:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888
+            ZOO_SERVERS: server.1=0.0.0.0:2888:3888 server.2=zoo2:2889:3889 server.3=zoo3:2890:3890
 
     zoo2:
         image: 31z4/zookeeper
@@ -51,9 +53,11 @@ services:
         hostname: zoo2
         ports:
             - 2182:2181
+	    - 2889:2888
+	    - 3889:3888
         environment:
             ZOO_MY_ID: 2
-            ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=0.0.0.0:2888:3888 server.3=zoo3:2888:3888
+            ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=0.0.0.0:2889:3889 server.3=zoo3:2890:3890
 
     zoo3:
         image: 31z4/zookeeper
@@ -61,9 +65,11 @@ services:
         hostname: zoo3
         ports:
             - 2183:2181
+	    - 2890:2888
+	    - 3890:3888
         environment:
             ZOO_MY_ID: 3
-            ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=zoo2:2888:3888 server.3=0.0.0.0:2888:3888
+            ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=zoo2:2889:3889 server.3=0.0.0.0:2890:3890
 ```
 
 This will start Zookeeper in [replicated mode](http://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_RunningReplicatedZooKeeper). Run `docker stack deploy -c stack.yml zookeeper` (or `docker-compose -f stack.yml up`) and wait for it to initialize completely. Ports `2181-2183` will be exposed.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ services:
         hostname: zoo1
         ports:
             - 2181:2181
-	    - 2888:2888
-	    - 3888:3888
+            - 2888:2888
+            - 3888:3888
         environment:
             ZOO_MY_ID: 1
             ZOO_SERVERS: server.1=0.0.0.0:2888:3888 server.2=zoo2:2889:3889 server.3=zoo3:2890:3890
@@ -53,8 +53,8 @@ services:
         hostname: zoo2
         ports:
             - 2182:2181
-	    - 2889:2888
-	    - 3889:3888
+            - 2889:2888
+            - 3889:3888
         environment:
             ZOO_MY_ID: 2
             ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=0.0.0.0:2889:3889 server.3=zoo3:2890:3890
@@ -65,8 +65,8 @@ services:
         hostname: zoo3
         ports:
             - 2183:2181
-	    - 2890:2888
-	    - 3890:3888
+            - 2890:2888
+            - 3890:3888
         environment:
             ZOO_MY_ID: 3
             ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=zoo2:2889:3889 server.3=0.0.0.0:2890:3890


### PR DESCRIPTION
We need to expose ports 2888 and 3888 for zookeeper container nodes to communicate with each other for leader election and proposals.