### PR TITLE
Introduce env variable ZOO_4LW_COMMANDS_WHITELIST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-zookeeper-docker.iml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+zookeeper-docker.iml

--- a/3.5.5/docker-entrypoint.sh
+++ b/3.5.5/docker-entrypoint.sh
@@ -32,6 +32,11 @@ if [[ ! -f "$ZOO_CONF_DIR/zoo.cfg" ]]; then
     for server in $ZOO_SERVERS; do
         echo "$server" >> "$CONFIG"
     done
+
+    if [[ -n $ZOO_4LW_COMMANDS_WHITELIST ]]; then
+        echo "4lw.commands.whitelist=$ZOO_4LW_COMMANDS_WHITELIST" >> "$CONFIG"
+    fi
+
 fi
 
 # Write myid only if it doesn't exist

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ Defaults to `3`. Zookeeper's [`autoPurge.snapRetainCount`](https://zookeeper.apa
 
 > When enabled, ZooKeeper auto purge feature retains the autopurge.snapRetainCount most recent snapshots and the corresponding transaction logs in the dataDir and dataLogDir respectively and deletes the rest. Defaults to 3. Minimum value is 3.
 
+### `ZOO_4LW_COMMANDS_WHITELIST`
+
+Defaults to `srvr`. Zookeeper's [`4lw.commands.whitelist`](https://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_clusterOptions)
+
+> A list of comma separated Four Letter Words commands that user wants to use. A valid Four Letter Words command must be put in this list else ZooKeeper server will not enable the command. By default the whitelist only contains "srvr" command which zkServer.sh uses. The rest of four letter word commands are disabled by default.
+
 ## Replicated mode
 
 Environment variables below are mandatory if you want to run Zookeeper in replicated mode.


### PR DESCRIPTION
Introduce environment variable ZOO_4LW_COMMANDS_WHITELIST to change configuration parameter `4lw.commands.whitelist cluster`.

Possible solution of request #76 