### PR TITLE
Add ability to run zookeeper from another user (ZOO_UID/ZOO_GID)

### DIFF
--- a/3.4.14/docker-entrypoint.sh
+++ b/3.4.14/docker-entrypoint.sh
@@ -2,10 +2,20 @@
 
 set -e
 
+# UID is read-only var in bash, but there is no GID,
+# hence let's define them both
+UID_=$(id -u)
+GID_=$(id -g)
+
+ZOO_UID=${ZOO_UID:-"$(id -u zookeeper)"}
+ZOO_GID=${ZOO_GID:-"$(id -g zookeeper)"}
+
 # Allow the container to be started with `--user`
-if [[ "$1" = 'zkServer.sh' && "$(id -u)" = '0' ]]; then
-    chown -R zookeeper "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR" "$ZOO_CONF_DIR"
-    exec gosu zookeeper "$0" "$@"
+if [[ "$1" = 'zkServer.sh' && $UID_ = 0 ]]; then
+    chown -R "$ZOO_UID":"$ZOO_GID" "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR" "$ZOO_LOG_DIR"
+    if [[ "$ZOO_UID" != "$UID_" ]] && [[ "$ZOO_GID" != "$GID_" ]]; then
+        exec gosu "$ZOO_UID":"$ZOO_GID" "$0" "$@"
+    fi
 fi
 
 # Generate the config only if it doesn't exist

--- a/3.5.6/docker-entrypoint.sh
+++ b/3.5.6/docker-entrypoint.sh
@@ -2,17 +2,27 @@
 
 set -e
 
+# UID is read-only var in bash, but there is no GID,
+# hence let's define them both
+UID_=$(id -u)
+GID_=$(id -g)
+
+ZOO_UID=${ZOO_UID:-"$(id -u zookeeper)"}
+ZOO_GID=${ZOO_GID:-"$(id -g zookeeper)"}
+
 # Allow the container to be started with `--user`
-if [[ "$1" = 'zkServer.sh' && "$(id -u)" = '0' ]]; then
-    chown -R zookeeper "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR" "$ZOO_CONF_DIR"
-    exec gosu zookeeper "$0" "$@"
+if [[ "$1" = 'zkServer.sh' && $UID_ = 0 ]]; then
+    chown -R "$ZOO_UID":"$ZOO_GID" "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR" "$ZOO_LOG_DIR"
+    if [[ "$ZOO_UID" != "$UID_" ]] && [[ "$ZOO_GID" != "$GID_" ]]; then
+        exec gosu "$ZOO_UID":"$ZOO_GID" "$0" "$@"
+    fi
 fi
 
 # Generate the config only if it doesn't exist
 if [[ ! -f "$ZOO_CONF_DIR/zoo.cfg" ]]; then
     CONFIG="$ZOO_CONF_DIR/zoo.cfg"
     {
-        echo "dataDir=$ZOO_DATA_DIR" 
+        echo "dataDir=$ZOO_DATA_DIR"
         echo "dataLogDir=$ZOO_DATA_LOG_DIR"
 
         echo "tickTime=$ZOO_TICK_TIME"


### PR DESCRIPTION
This will allow to run zookeeper from root inside container, this maybe
useful in case userns is enabled for docker and the data directories are
bypassed from the host, in this case the files will be created from the
"correct" user.