### PR TITLE
Support for multi-arch (amd64, arm/v7, arm64/v8, ppc64le, s390x)

### DIFF
--- a/3.4.14/Dockerfile
+++ b/3.4.14/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-slim
+FROM adoptopenjdk:latest
 
 ENV ZOO_CONF_DIR=/conf \
     ZOO_DATA_DIR=/data \
@@ -25,13 +25,10 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         dirmngr \
-        gosu \
         gnupg \
         netcat \
         wget; \
     rm -rf /var/lib/apt/lists/*; \
-# Verify that gosu binary works
-    gosu nobody true
 
 ARG GPG_KEY=3F7A1D16FA4217B1DC75E1C9FFE35B7F15DFA1BA
 ARG DISTRO_NAME=zookeeper-3.4.14

--- a/3.4.14/Dockerfile
+++ b/3.4.14/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:latest
+FROM adoptopenjdk:8u232-b09-jre-hotspot
 
 ENV ZOO_CONF_DIR=/conf \
     ZOO_DATA_DIR=/data \

--- a/3.4.14/docker-entrypoint.sh
+++ b/3.4.14/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 # Allow the container to be started with `--user`
 if [[ "$1" = 'zkServer.sh' && "$(id -u)" = '0' ]]; then
     chown -R zookeeper "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR" "$ZOO_CONF_DIR"
-    exec gosu zookeeper "$0" "$@"
+    exec su zookeeper "$0" "$@"
 fi
 
 # Generate the config only if it doesn't exist

--- a/3.5.6/Dockerfile
+++ b/3.5.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:latest
+FROM adoptopenjdk:8u232-b09-jre-hotspot
 
 ENV ZOO_CONF_DIR=/conf \
     ZOO_DATA_DIR=/data \

--- a/3.5.6/Dockerfile
+++ b/3.5.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-slim
+FROM adoptopenjdk:latest
 
 ENV ZOO_CONF_DIR=/conf \
     ZOO_DATA_DIR=/data \
@@ -27,13 +27,10 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         dirmngr \
-        gosu \
         gnupg \
         netcat \
         wget; \
-    rm -rf /var/lib/apt/lists/*; \
-# Verify that gosu binary works
-    gosu nobody true
+    rm -rf /var/lib/apt/lists/*;
 
 ARG GPG_KEY=BBE7232D7991050B54C8EA0ADC08637CA615D22C
 ARG SHORT_DISTRO_NAME=zookeeper-3.5.6

--- a/3.5.6/docker-entrypoint.sh
+++ b/3.5.6/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 # Allow the container to be started with `--user`
 if [[ "$1" = 'zkServer.sh' && "$(id -u)" = '0' ]]; then
     chown -R zookeeper "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR" "$ZOO_CONF_DIR"
-    exec gosu zookeeper "$0" "$@"
+    exec su zookeeper "$0" "$@"
 fi
 
 # Generate the config only if it doesn't exist


### PR DESCRIPTION
This switches to the adoptopenjdk base image and uses their latest tag to support all the architectures listed above.  This should resolve #87, and not mentioned in #87, the current zookeeper tags don't even support arm64, only amd64 because the base openjdk 8-slim tag only supports amd64.

I've built and published the result of this build to the docker hub as [kymeric/zookeeper](https://hub.docker.com/repository/docker/kymeric/zookeeper/tags?page=1).  The sequence to build using docker and buildx:

## BUILD

### requirements
- ubuntu 19.10
- docker 19.03.6 with experimental enabled in daemon and client
- apt install qemu-user qemu-user-static

### steps
```bash
docker buildx create --name mp --platform=linux/amd64,linux/arm64/v8,linux/arm/v7,linux/ppc64le,linux/s390x --use
docker buildx inspect mp --bootstrap
docker buildx build --platform=linux/amd64,linux/arm64/v8,linux/arm/v7,linux/ppc64le,linux/s390x -t kymeric/zookeeper:latest --push .
```

## TESTING

### kubernetes
I'm testing on arm64 and amd64 in Kubernetes (hybrid kubernetes cluster) by deploying the kafka and zookeeper charts with this command (also uses my custom build of cp-kafka for arm64):

```bash
helm install kafka incubator/kafka --set image=kymeric/cp-kafka --set imageTag=latest --set zookeeper.image.repository=kymeric/zookeeper --set zookeeper.image.tag=latest
```

I'll be testing this over the next few weeks but wanted to start the pull request now to get feedback.

## Notes
- openjdk:8-slim only supports amd64
- adoptopenjdk:latest supports amd64, arm64, arm/v7, ppc64le, s390x

### TODO
- This includes a switch from openjdk base image to adoptopenjdk image and a bump from jre 8 to jre 11.  What testing is required?
- gosu doesn't work for buildx / qemu-user arm emulation so I switched to su command.  Are there issues with this?  I don't think gosu is needed for a simple switch user command