### PR TITLE
Add SSL quorum related options

### DIFF
--- a/3.5.7/Dockerfile
+++ b/3.5.7/Dockerfile
@@ -11,7 +11,8 @@ ENV ZOO_CONF_DIR=/conf \
     ZOO_AUTOPURGE_SNAPRETAINCOUNT=3 \
     ZOO_MAX_CLIENT_CNXNS=60 \
     ZOO_STANDALONE_ENABLED=true \
-    ZOO_ADMINSERVER_ENABLED=true
+    ZOO_ADMINSERVER_ENABLED=true \
+    ZOO_SERVER_CNXN_FACTORY=org.apache.zookeeper.server.NettyServerCnxnFactory
 
 # Add a user with an explicit UID/GID and create necessary directories
 RUN set -eux; \

--- a/3.5.7/docker-entrypoint.sh
+++ b/3.5.7/docker-entrypoint.sh
@@ -37,6 +37,20 @@ if [[ ! -f "$ZOO_CONF_DIR/zoo.cfg" ]]; then
         echo "4lw.commands.whitelist=$ZOO_4LW_COMMANDS_WHITELIST" >> "$CONFIG"
     fi
 
+    if [[ -n $ZOO_SSL_QUORUM ]]; then
+        {
+            echo "sslQuorum=$ZOO_SSL_QUORUM"
+            echo "serverCnxnFactory=$ZOO_SERVER_CNXN_FACTORY"
+            echo "ssl.quorum.keyStore.location=$ZOO_SSL_QUORUM_KEYSTORE_LOCATION"
+            echo "ssl.quorum.keyStore.password=$ZOO_SSL_QUORUM_KEYSTORE_PASSWORD"
+            echo "ssl.quorum.trustStore.location=$ZOO_SSL_QUORUM_TRUSTSTORE_LOCATION"
+            echo "ssl.quorum.trustStore.password=$ZOO_SSL_QUORUM_TRUSTSTORE_PASSWORD"
+        } >> "$CONFIG"
+    fi
+
+    if [[ -n $ZOO_PORT_UNIFICATION ]]; then
+        echo "portUnification=$ZOO_PORT_UNIFICATION" >> "$CONFIG"
+    fi
 fi
 
 # Write myid only if it doesn't exist


### PR DESCRIPTION
This PR allows to run ZK quorum [over TLS](https://github.com/apache/zookeeper/blob/master/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md#communication-using-the-netty-framework) and upgrading existing non-TLS cluster with no downtime since 3.5.5.