### PR TITLE
Possibility to add extra config in zoo.cfg file through environment variable

### DIFF
--- a/3.4.14/docker-entrypoint.sh
+++ b/3.4.14/docker-entrypoint.sh
@@ -27,6 +27,10 @@ if [[ ! -f "$ZOO_CONF_DIR/zoo.cfg" ]]; then
     for server in $ZOO_SERVERS; do
         echo "$server" >> "$CONFIG"
     done
+
+    for cfg_extra_entry in $ZOO_CFG_EXTRA; do
+        echo "$cfg_extra_entry" >> "$CONFIG"
+    done
 fi
 
 # Write myid only if it doesn't exist

--- a/3.5.8/docker-entrypoint.sh
+++ b/3.5.8/docker-entrypoint.sh
@@ -37,6 +37,9 @@ if [[ ! -f "$ZOO_CONF_DIR/zoo.cfg" ]]; then
         echo "4lw.commands.whitelist=$ZOO_4LW_COMMANDS_WHITELIST" >> "$CONFIG"
     fi
 
+    for cfg_extra_entry in $ZOO_CFG_EXTRA; do
+        echo "$cfg_extra_entry" >> "$CONFIG"
+    done
 fi
 
 # Write myid only if it doesn't exist

--- a/3.6.1/docker-entrypoint.sh
+++ b/3.6.1/docker-entrypoint.sh
@@ -37,6 +37,9 @@ if [[ ! -f "$ZOO_CONF_DIR/zoo.cfg" ]]; then
         echo "4lw.commands.whitelist=$ZOO_4LW_COMMANDS_WHITELIST" >> "$CONFIG"
     fi
 
+    for cfg_extra_entry in $ZOO_CFG_EXTRA; do
+        echo "$cfg_extra_entry" >> "$CONFIG"
+    done
 fi
 
 # Write myid only if it doesn't exist


### PR DESCRIPTION
This fix allow to add all parameters in `zoo.cfg` by using `ZOO_CFG_EXTRA` environment variable.  

This provide extra flexibility when using docker.
For example, no need to create custom image that only override `zoo.cfg` and adds:
`metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider`

Please merge, it's very needed=)