### PR TITLE
Use dumb-init

### DIFF
--- a/3.5.9/Dockerfile
+++ b/3.5.9/Dockerfile
@@ -27,6 +27,7 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         dirmngr \
+        dumb-init \
         gosu \
         gnupg \
         netcat \
@@ -80,5 +81,5 @@ ENV PATH=$PATH:/$DISTRO_NAME/bin \
     ZOOCFGDIR=$ZOO_CONF_DIR
 
 COPY docker-entrypoint.sh /
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/docker-entrypoint.sh"]
 CMD ["zkServer.sh", "start-foreground"]

--- a/3.6.3/Dockerfile
+++ b/3.6.3/Dockerfile
@@ -27,6 +27,7 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         dirmngr \
+        dumb-init \
         gosu \
         gnupg \
         netcat \
@@ -80,5 +81,5 @@ ENV PATH=$PATH:/$DISTRO_NAME/bin \
     ZOOCFGDIR=$ZOO_CONF_DIR
 
 COPY docker-entrypoint.sh /
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/docker-entrypoint.sh"]
 CMD ["zkServer.sh", "start-foreground"]

--- a/3.7.1/Dockerfile
+++ b/3.7.1/Dockerfile
@@ -27,6 +27,7 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         dirmngr \
+        dumb-init \
         gosu \
         gnupg \
         netcat \
@@ -80,5 +81,5 @@ ENV PATH=$PATH:/$DISTRO_NAME/bin \
     ZOOCFGDIR=$ZOO_CONF_DIR
 
 COPY docker-entrypoint.sh /
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/docker-entrypoint.sh"]
 CMD ["zkServer.sh", "start-foreground"]

--- a/3.8.0/Dockerfile
+++ b/3.8.0/Dockerfile
@@ -27,6 +27,7 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         dirmngr \
+        dumb-init \
         gosu \
         gnupg \
         netcat \
@@ -80,5 +81,5 @@ ENV PATH=$PATH:/$DISTRO_NAME/bin \
     ZOOCFGDIR=$ZOO_CONF_DIR
 
 COPY docker-entrypoint.sh /
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/docker-entrypoint.sh"]
 CMD ["zkServer.sh", "start-foreground"]


### PR DESCRIPTION
Currently Zookeeper runs as PID 1. This is a problem because it does not
reap child processes. When run under Kubernetes, if a command is used to
check the liveness of Zookeeper such as
```
  test "$(echo ruok | nc -q 3 127.0.0.1 2181)" = imok
```
then these shell processes will linger in the container as zombies and
pile up over time. Depending on the frequency of the checks and how long
Zookeeper is up, this could lead to an excessive number of processes and
eventually cause an outage, or cause some other weird behaviors on the
host, such as `ps` taking 20min to print anything.