### PR TITLE
Add support for custom init scripts

### DIFF
--- a/3.7.2-jre11/Dockerfile
+++ b/3.7.2-jre11/Dockerfile
@@ -32,6 +32,7 @@ RUN set -eux; \
         netcat \
         wget; \
     rm -rf /var/lib/apt/lists/*; \
+    mkdir /docker-entrypoint.d && \
 # Verify that gosu binary works
     gosu nobody true
 

--- a/3.7.2-jre11/docker-entrypoint.sh
+++ b/3.7.2-jre11/docker-entrypoint.sh
@@ -8,6 +8,36 @@ if [[ "$1" = 'zkServer.sh' && "$(id -u)" = '0' ]]; then
     exec gosu zookeeper "$0" "$@"
 fi
 
+if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
+    echo "Loading shell scripts in /docker-entrypoint.d/"
+    for f in $(find "/docker-entrypoint.d/" -follow -type f -print | sort -V); do
+        case "$f" in
+            *.envsh)
+                if [ -x "$f" ]; then
+                    echo "Sourcing $f";
+                    . "$f"
+                else
+                    # warn on shell scripts without exec bit
+                    echo "Ignoring $f, not executable";
+                fi
+                ;;
+            *.sh)
+                if [ -x "$f" ]; then
+                    echo "Launching $f";
+                    "$f"
+                else
+                    # warn on shell scripts without exec bit
+                    echo "Ignoring $f, not executable";
+                fi
+                ;;
+            *) echo "Ignoring $f";;
+        esac
+    done
+    echo "Loaded shell scripts in /docker-entrypoint.d/"
+else
+    echo "No files found in /docker-entrypoint.d/"
+fi
+
 # Generate the config only if it doesn't exist
 if [[ ! -f "$ZOO_CONF_DIR/zoo.cfg" ]]; then
     CONFIG="$ZOO_CONF_DIR/zoo.cfg"

--- a/3.7.2/Dockerfile
+++ b/3.7.2/Dockerfile
@@ -32,6 +32,7 @@ RUN set -eux; \
         netcat \
         wget; \
     rm -rf /var/lib/apt/lists/*; \
+    mkdir /docker-entrypoint.d && \
 # Verify that gosu binary works
     gosu nobody true
 

--- a/3.7.2/docker-entrypoint.sh
+++ b/3.7.2/docker-entrypoint.sh
@@ -8,6 +8,36 @@ if [[ "$1" = 'zkServer.sh' && "$(id -u)" = '0' ]]; then
     exec gosu zookeeper "$0" "$@"
 fi
 
+if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
+    echo "Loading shell scripts in /docker-entrypoint.d/"
+    for f in $(find "/docker-entrypoint.d/" -follow -type f -print | sort -V); do
+        case "$f" in
+            *.envsh)
+                if [ -x "$f" ]; then
+                    echo "Sourcing $f";
+                    . "$f"
+                else
+                    # warn on shell scripts without exec bit
+                    echo "Ignoring $f, not executable";
+                fi
+                ;;
+            *.sh)
+                if [ -x "$f" ]; then
+                    echo "Launching $f";
+                    "$f"
+                else
+                    # warn on shell scripts without exec bit
+                    echo "Ignoring $f, not executable";
+                fi
+                ;;
+            *) echo "Ignoring $f";;
+        esac
+    done
+    echo "Loaded shell scripts in /docker-entrypoint.d/"
+else
+    echo "No files found in /docker-entrypoint.d/"
+fi
+
 # Generate the config only if it doesn't exist
 if [[ ! -f "$ZOO_CONF_DIR/zoo.cfg" ]]; then
     CONFIG="$ZOO_CONF_DIR/zoo.cfg"

--- a/3.8.4/Dockerfile
+++ b/3.8.4/Dockerfile
@@ -32,6 +32,7 @@ RUN set -eux; \
         netcat \
         wget; \
     rm -rf /var/lib/apt/lists/*; \
+    mkdir /docker-entrypoint.d && \
 # Verify that gosu binary works
     gosu nobody true
 

--- a/3.8.4/docker-entrypoint.sh
+++ b/3.8.4/docker-entrypoint.sh
@@ -8,6 +8,36 @@ if [[ "$1" = 'zkServer.sh' && "$(id -u)" = '0' ]]; then
     exec gosu zookeeper "$0" "$@"
 fi
 
+if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
+    echo "Loading shell scripts in /docker-entrypoint.d/"
+    for f in $(find "/docker-entrypoint.d/" -follow -type f -print | sort -V); do
+        case "$f" in
+            *.envsh)
+                if [ -x "$f" ]; then
+                    echo "Sourcing $f";
+                    . "$f"
+                else
+                    # warn on shell scripts without exec bit
+                    echo "Ignoring $f, not executable";
+                fi
+                ;;
+            *.sh)
+                if [ -x "$f" ]; then
+                    echo "Launching $f";
+                    "$f"
+                else
+                    # warn on shell scripts without exec bit
+                    echo "Ignoring $f, not executable";
+                fi
+                ;;
+            *) echo "Ignoring $f";;
+        esac
+    done
+    echo "Loaded shell scripts in /docker-entrypoint.d/"
+else
+    echo "No files found in /docker-entrypoint.d/"
+fi
+
 # Generate the config only if it doesn't exist
 if [[ ! -f "$ZOO_CONF_DIR/zoo.cfg" ]]; then
     CONFIG="$ZOO_CONF_DIR/zoo.cfg"

--- a/3.9.2/Dockerfile
+++ b/3.9.2/Dockerfile
@@ -32,6 +32,7 @@ RUN set -eux; \
         netcat \
         wget; \
     rm -rf /var/lib/apt/lists/*; \
+    mkdir /docker-entrypoint.d && \
 # Verify that gosu binary works
     gosu nobody true
 

--- a/3.9.2/docker-entrypoint.sh
+++ b/3.9.2/docker-entrypoint.sh
@@ -8,6 +8,36 @@ if [[ "$1" = 'zkServer.sh' && "$(id -u)" = '0' ]]; then
     exec gosu zookeeper "$0" "$@"
 fi
 
+if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
+    echo "Loading shell scripts in /docker-entrypoint.d/"
+    for f in $(find "/docker-entrypoint.d/" -follow -type f -print | sort -V); do
+        case "$f" in
+            *.envsh)
+                if [ -x "$f" ]; then
+                    echo "Sourcing $f";
+                    . "$f"
+                else
+                    # warn on shell scripts without exec bit
+                    echo "Ignoring $f, not executable";
+                fi
+                ;;
+            *.sh)
+                if [ -x "$f" ]; then
+                    echo "Launching $f";
+                    "$f"
+                else
+                    # warn on shell scripts without exec bit
+                    echo "Ignoring $f, not executable";
+                fi
+                ;;
+            *) echo "Ignoring $f";;
+        esac
+    done
+    echo "Loaded shell scripts in /docker-entrypoint.d/"
+else
+    echo "No files found in /docker-entrypoint.d/"
+fi
+
 # Generate the config only if it doesn't exist
 if [[ ! -f "$ZOO_CONF_DIR/zoo.cfg" ]]; then
     CONFIG="$ZOO_CONF_DIR/zoo.cfg"


### PR DESCRIPTION
See #145

Add support for custom init scripts which can be mounted to `/docker-entrypoint.d/` directory.

This will allow more easier, flexible and elegant customization. For example, to deploy a ZooKeeper cluster in Kubernetes, user can mount a custom init script to calculate `ZOO_MY_ID` for each instance.

The idea and code is borrowed from [official Nginx image](https://github.com/nginxinc/docker-nginx/blob/9abe4ae472b3332665fad9b12ee146dc242e775c/entrypoint/docker-entrypoint.sh#L17).

There are two kinds of init scripts:

* `*.envsh`: environment script, it will be executed by `source` command, and can be used to export environment variables which will be visible to `docker-entrypoint.sh`
* `*.sh`: normal script, normally it should have a shebang to declare how to execute it

Note:

* Files that not ends with `.envsh` or `.sh` will be ignored
* Each init script must have execute permission, otherwise it will be ignored to reduce security risks
* If the container is started by root user (the default case), the init scripts will be executed after switching to `zookeeper` user


Kubernetes example to mount a init script from ConfigMap:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: zookeeper-config
data:
  set-my-id.envsh: |
    #!/bin/bash
    HOST=`hostname -s`
    DOMAIN=`hostname -d`
    if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
        NAME=${BASH_REMATCH[1]}
        ORD=${BASH_REMATCH[2]}
    else
        echo "Failed to parse name and ordinal of Pod"
        exit 1
    fi
    servers=
    for (( i=1; i<=$ZOO_SERVERS_COUNT; i++ )); do
        [[ -n "$servers" ]] && servers+=" "
        servers+="server.$i=$NAME-$((i-1)).$DOMAIN:2888:3888;2181"
    done
    export ZOO_MY_ID="$((ORD+1))"
    export ZOO_SERVERS="$servers"
    echo "Setting ZOO_MY_ID=$ZOO_MY_ID"
    echo "Setting ZOO_SERVERS=$ZOO_SERVERS"
---
apiVersion: apps/v1
kind: StatefulSet
spec:
  template:
    spec:
      volumes:
        - name: zookeeper-config
          configMap:
            name: zookeeper-config
            items:
              - key: set-my-id.envsh
                path: set-my-id.envsh
                mode: 0555

      containers:
        - name: kubernetes-zookeeper
          image: zookeeper:3.9.2
          volumeMounts:
            - name: zookeeper-config
              mountPath: /docker-entrypoint.d/set-my-id.envsh
              subPath: set-my-id.envsh

```
