### PR TITLE
Create all directories if don't exists

### DIFF
--- a/3.9.4/docker-entrypoint.sh
+++ b/3.9.4/docker-entrypoint.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Create directories if they don't exist
+mkdir -p "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR"
+
 # Allow the container to be started with `--user`
 if [[ "$1" = 'zkServer.sh' && "$(id -u)" = '0' ]]; then
     chown -R zookeeper "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR"


### PR DESCRIPTION
The problem:
In our project, we are migrating from using Bitnami zookeeper to the official one, and we need to support both fresh installation and migration. To support the migration, we must set ZOO_DATA_DIR to a different path in our default configuration. On fresh installations, the `docker-entrypoint `script fails because this directory does not exist.

Solution:
Add creation of all directories if they don't exist in the `docker-entrypoint` script